### PR TITLE
Add configurable downstreams and responses for keywords

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -16,6 +16,7 @@ responses = "*"
 sentry-sdk = "*"
 requests = "*"
 twilio = "*"
+pydantic = "*"
 
 [requires]
 python_version = "3.7"
@@ -28,6 +29,6 @@ autoflake = "autoflake --remove-unused-variables --remove-all-unused-imports --i
 isort = "isort --recursive app"
 black = "black app"
 mypy = "mypy app"
-pytest = "bash -c \"SENTRY_DSN='' SENTRY_ENVIRONMENT='' TWILIO_AUTH_TOKEN='' TWILIO_CALLBACK_URL='' DOWNSTREAM_URLS='' pytest app\""
+pytest = "pytest app"
 test = "bash -c 'pipenv run mypy && pipenv run pytest'"
 format = "bash -c 'pipenv run autoflake && pipenv run isort && pipenv run black'"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "8ddbe03a041d6f0ce9e02128fdbfabd10fc4049f839b41215deffa4e891ebf42"
+            "sha256": "79176086a3395e847145396f7dd32fc0da4563a051f98656b3ce65b0318bb893"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -38,6 +38,29 @@
             "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
             "version": "==2.10"
         },
+        "pydantic": {
+            "hashes": [
+                "sha256:1783c1d927f9e1366e0e0609ae324039b2479a1a282a98ed6a6836c9ed02002c",
+                "sha256:2dc946b07cf24bee4737ced0ae77e2ea6bc97489ba5a035b603bd1b40ad81f7e",
+                "sha256:2de562a456c4ecdc80cf1a8c3e70c666625f7d02d89a6174ecf63754c734592e",
+                "sha256:36dbf6f1be212ab37b5fda07667461a9219c956181aa5570a00edfb0acdfe4a1",
+                "sha256:3fa799f3cfff3e5f536cbd389368fc96a44bb30308f258c94ee76b73bd60531d",
+                "sha256:40d765fa2d31d5be8e29c1794657ad46f5ee583a565c83cea56630d3ae5878b9",
+                "sha256:418b84654b60e44c0cdd5384294b0e4bc1ebf42d6e873819424f3b78b8690614",
+                "sha256:4900b8820b687c9a3ed753684337979574df20e6ebe4227381d04b3c3c628f99",
+                "sha256:530d7222a2786a97bc59ee0e0ebbe23728f82974b1f1ad9a11cd966143410633",
+                "sha256:54122a8ed6b75fe1dd80797f8251ad2063ea348a03b77218d73ea9fe19bd4e73",
+                "sha256:6c3f162ba175678218629f446a947e3356415b6b09122dcb364e58c442c645a7",
+                "sha256:b49c86aecde15cde33835d5d6360e55f5e0067bb7143a8303bf03b872935c75b",
+                "sha256:b5b3489cb303d0f41ad4a7390cf606a5f2c7a94dcba20c051cd1c653694cb14d",
+                "sha256:cf3933c98cb5e808b62fae509f74f209730b180b1e3c3954ee3f7949e083a7df",
+                "sha256:eb75dc1809875d5738df14b6566ccf9fd9c0bcde4f36b72870f318f16b9f5c20",
+                "sha256:f769141ab0abfadf3305d4fcf36660e5cf568a666dd3efab7c3d4782f70946b1",
+                "sha256:f8af9b840a9074e08c0e6dc93101de84ba95df89b267bf7151d74c553d66833b"
+            ],
+            "index": "pypi",
+            "version": "==1.6.1"
+        },
         "pyjwt": {
             "hashes": [
                 "sha256:5c6eca3c2940464d106b99ba83b00c6add741c9becaec087fb7ccdefea71350e",
@@ -62,11 +85,11 @@
         },
         "sentry-sdk": {
             "hashes": [
-                "sha256:c9c0fa1412bad87104c4eee8dd36c7bbf60b0d92ae917ab519094779b22e6d9a",
-                "sha256:e159f7c919d19ae86e5a4ff370fccc45149fab461fbeb93fb5a735a0b33a9cb1"
+                "sha256:1d91a0059d2d8bb980bec169578035c2f2d4b93cd8a4fb5b85c81904d33e221a",
+                "sha256:6222cf623e404c3e62b8e0e81c6db866ac2d12a663b7c1f7963350e3f397522a"
             ],
             "index": "pypi",
-            "version": "==0.17.8"
+            "version": "==0.18.0"
         },
         "six": {
             "hashes": [
@@ -78,10 +101,10 @@
         },
         "twilio": {
             "hashes": [
-                "sha256:df1cf8f7e62fbe4d412e66204ee7f948cd31ff18173ff4690475834174eedaf0"
+                "sha256:ccab1e0831486e5e3833e2aab5a677453ef2a88aed3d988b6831b876ebb0374d"
             ],
             "index": "pypi",
-            "version": "==6.45.3"
+            "version": "==6.45.4"
         },
         "urllib3": {
             "hashes": [
@@ -161,19 +184,11 @@
         },
         "isort": {
             "hashes": [
-                "sha256:6187a9f1ce8784cbc6d1b88790a43e6083a6302f03e9ae482acc0f232a98c843",
-                "sha256:c16eaa7432a1c004c585d79b12ad080c6c421dd18fe27982ca11f95e6898e432"
+                "sha256:36f0c6659b9000597e92618d05b72d4181104cf59472b1c6a039e3783f930c95",
+                "sha256:ba040c24d20aa302f78f4747df549573ae1eaf8e1084269199154da9c483f07f"
             ],
             "index": "pypi",
-            "version": "==5.5.3"
-        },
-        "more-itertools": {
-            "hashes": [
-                "sha256:6f83822ae94818eae2612063a5101a7311e68ae8002005b5e05f03fd74a86a20",
-                "sha256:9b30f12df9393f0d28af9210ff8efe48d10c94f73e5daf886f10c4b0b0b4f03c"
-            ],
-            "markers": "python_version >= '3.5'",
-            "version": "==8.5.0"
+            "version": "==5.5.4"
         },
         "mypy": {
             "hashes": [
@@ -251,37 +266,37 @@
         },
         "pytest": {
             "hashes": [
-                "sha256:0e37f61339c4578776e090c3b8f6b16ce4db333889d65d0efb305243ec544b40",
-                "sha256:c8f57c2a30983f469bf03e68cdfa74dc474ce56b8f280ddcb080dfd91df01043"
+                "sha256:7a8190790c17d79a11f847fba0b004ee9a8122582ebff4729a082c109e81a4c9",
+                "sha256:8f593023c1a0f916110285b6efd7f99db07d59546e3d8c36fc60e2ab05d3be92"
             ],
             "index": "pypi",
-            "version": "==6.0.2"
+            "version": "==6.1.1"
         },
         "regex": {
             "hashes": [
-                "sha256:0dc64ee3f33cd7899f79a8d788abfbec168410be356ed9bd30bbd3f0a23a7204",
-                "sha256:1269fef3167bb52631ad4fa7dd27bf635d5a0790b8e6222065d42e91bede4162",
-                "sha256:14a53646369157baa0499513f96091eb70382eb50b2c82393d17d7ec81b7b85f",
-                "sha256:3a3af27a8d23143c49a3420efe5b3f8cf1a48c6fc8bc6856b03f638abc1833bb",
-                "sha256:46bac5ca10fb748d6c55843a931855e2727a7a22584f302dd9bb1506e69f83f6",
-                "sha256:4c037fd14c5f4e308b8370b447b469ca10e69427966527edcab07f52d88388f7",
-                "sha256:51178c738d559a2d1071ce0b0f56e57eb315bcf8f7d4cf127674b533e3101f88",
-                "sha256:5ea81ea3dbd6767873c611687141ec7b06ed8bab43f68fad5b7be184a920dc99",
-                "sha256:6961548bba529cac7c07af2fd4d527c5b91bb8fe18995fed6044ac22b3d14644",
-                "sha256:75aaa27aa521a182824d89e5ab0a1d16ca207318a6b65042b046053cfc8ed07a",
-                "sha256:7a2dd66d2d4df34fa82c9dc85657c5e019b87932019947faece7983f2089a840",
-                "sha256:8a51f2c6d1f884e98846a0a9021ff6861bdb98457879f412fdc2b42d14494067",
-                "sha256:9c568495e35599625f7b999774e29e8d6b01a6fb684d77dee1f56d41b11b40cd",
-                "sha256:9eddaafb3c48e0900690c1727fba226c4804b8e6127ea409689c3bb492d06de4",
-                "sha256:bbb332d45b32df41200380fff14712cb6093b61bd142272a10b16778c418e98e",
-                "sha256:bc3d98f621898b4a9bc7fecc00513eec8f40b5b83913d74ccb445f037d58cd89",
-                "sha256:c11d6033115dc4887c456565303f540c44197f4fc1a2bfb192224a301534888e",
-                "sha256:c50a724d136ec10d920661f1442e4a8b010a4fe5aebd65e0c2241ea41dbe93dc",
-                "sha256:d0a5095d52b90ff38592bbdc2644f17c6d495762edf47d876049cfd2968fbccf",
-                "sha256:d6cff2276e502b86a25fd10c2a96973fdb45c7a977dca2138d661417f3728341",
-                "sha256:e46d13f38cfcbb79bfdb2964b0fe12561fe633caf964a77a5f8d4e45fe5d2ef7"
+                "sha256:088afc8c63e7bd187a3c70a94b9e50ab3f17e1d3f52a32750b5b77dbe99ef5ef",
+                "sha256:1fe0a41437bbd06063aa184c34804efa886bcc128222e9916310c92cd54c3b4c",
+                "sha256:41bb65f54bba392643557e617316d0d899ed5b4946dccee1cb6696152b29844b",
+                "sha256:4318d56bccfe7d43e5addb272406ade7a2274da4b70eb15922a071c58ab0108c",
+                "sha256:4707f3695b34335afdfb09be3802c87fa0bc27030471dbc082f815f23688bc63",
+                "sha256:5533a959a1748a5c042a6da71fe9267a908e21eded7a4f373efd23a2cbdb0ecc",
+                "sha256:5f18875ac23d9aa2f060838e8b79093e8bb2313dbaaa9f54c6d8e52a5df097be",
+                "sha256:60b0e9e6dc45683e569ec37c55ac20c582973841927a85f2d8a7d20ee80216ab",
+                "sha256:84e9407db1b2eb368b7ecc283121b5e592c9aaedbe8c78b1a2f1102eb2e21d19",
+                "sha256:8d69cef61fa50c8133382e61fd97439de1ae623fe943578e477e76a9d9471637",
+                "sha256:9a02d0ae31d35e1ec12a4ea4d4cca990800f66a917d0fb997b20fbc13f5321fc",
+                "sha256:9bc13e0d20b97ffb07821aa3e113f9998e84994fe4d159ffa3d3a9d1b805043b",
+                "sha256:a6f32aea4260dfe0e55dc9733ea162ea38f0ea86aa7d0f77b15beac5bf7b369d",
+                "sha256:ae91972f8ac958039920ef6e8769277c084971a142ce2b660691793ae44aae6b",
+                "sha256:c570f6fa14b9c4c8a4924aaad354652366577b4f98213cf76305067144f7b100",
+                "sha256:d23a18037313714fb3bb5a94434d3151ee4300bae631894b1ac08111abeaa4a3",
+                "sha256:eaf548d117b6737df379fdd53bdde4f08870e66d7ea653e230477f071f861121",
+                "sha256:ebbe29186a3d9b0c591e71b7393f1ae08c83cb2d8e517d2a822b8f7ec99dfd8b",
+                "sha256:eda4771e0ace7f67f58bc5b560e27fb20f32a148cbc993b0c3835970935c2707",
+                "sha256:f1b3afc574a3db3b25c89161059d857bd4909a1269b0b3cb3c904677c8c4a3f7",
+                "sha256:f2388013e68e750eaa16ccbea62d4130180c26abb1d8e5d584b9baf69672b30f"
             ],
-            "version": "==2020.7.14"
+            "version": "==2020.9.27"
         },
         "requests": {
             "hashes": [

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "79176086a3395e847145396f7dd32fc0da4563a051f98656b3ce65b0318bb893"
+            "sha256": "ad9b1d6555e04115335b31b18a76253fc94ed55e7cfe595eb92a27bbcc2ffe00"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -174,6 +174,14 @@
             ],
             "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
             "version": "==2.10"
+        },
+        "importlib-metadata": {
+            "hashes": [
+                "sha256:77a540690e24b0305878c37ffd421785a6f7e53c8b5720d211b211de8d0e95da",
+                "sha256:cefa1a2f919b866c5beb7c9f7b0ebb4061f30a8a9bf16d609b000e2dfaceb9c3"
+            ],
+            "index": "pypi",
+            "version": "==2.0.0"
         },
         "iniconfig": {
             "hashes": [
@@ -370,6 +378,14 @@
             ],
             "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4' and python_version < '4'",
             "version": "==1.25.10"
+        },
+        "zipp": {
+            "hashes": [
+                "sha256:64ad89efee774d1897a58607895d80789c59778ea02185dd846ac38394a8642b",
+                "sha256:eed8ec0b8d1416b2ca33516a37a08892442f3954dee131e92cfd92d8fe3e7066"
+            ],
+            "markers": "python_version >= '3.6'",
+            "version": "==3.3.0"
         }
     }
 }

--- a/app/config.py
+++ b/app/config.py
@@ -1,0 +1,58 @@
+from typing import List, Dict, Any, Optional
+import base64
+import json
+from pydantic import BaseModel, validator
+import re
+
+# From https://github.com/django/django/blob/stable/1.3.x/django/core/validators.py#L45
+# but no ftp:// support
+url_regex = re.compile(
+    r"^(?:http)s?://"  # http:// or https://
+    r"(?:(?:[A-Z0-9](?:[A-Z0-9-]{0,61}[A-Z0-9])?\.)+(?:[A-Z]{2,6}\.?|[A-Z0-9-]{2,}\.?)|"  # domain...
+    r"localhost|"  # localhost...
+    r"\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3})"  # ...or ip
+    r"(?::\d+)?"  # optional port
+    r"(?:/?|[/?]\S+)$",
+    re.IGNORECASE,
+)
+
+
+class KeywordConfig(BaseModel):
+    downstreams: List[str]
+    responder: Optional[int]
+
+    @validator("responder")
+    def responder_must_be_a_valid_index(cls, v, values, **kwargs):
+        if v is not None:
+            if v < 0:
+                raise ValueError("responder must be >= 0")
+
+            if v >= len(values.get("downstreams", [])):
+                raise ValueError("responder is out-of-bounds of the downstreams list")
+
+        return v
+
+    @validator("downstreams")
+    def downstreams_must_be_urls(cls, v):
+        for url in v:
+            if not url_regex.fullmatch(url):
+                raise ValueError(f"Invalid URL: {url}")
+
+        return v
+
+
+class Config(BaseModel):
+    default: KeywordConfig
+    keywords: Dict[str, KeywordConfig]
+
+    @validator("keywords")
+    def normalize_keywords(cls, keywords):
+        return {k.lower().strip(): v for k, v in keywords.items()}
+
+
+def parse_config(config_env: str) -> Config:
+    # Base64-decode the config. We have to base64-encode because Lambda does
+    # not support having commas in environment variables
+    config = json.loads(base64.b64decode(config_env))
+    return Config(**config)
+

--- a/app/config_test.py
+++ b/app/config_test.py
@@ -1,0 +1,153 @@
+import pytest
+import base64
+import json
+from .config import KeywordConfig, Config, parse_config
+from pydantic import ValidationError
+
+
+def test_valid_config():
+    assert parse_config(
+        base64.b64encode(
+            json.dumps(
+                {
+                    "default": {
+                        "downstreams": [
+                            "http://a.com",
+                            "https://b.example.com:123/a/b?c#d",
+                        ],
+                        "responder": 1,
+                    },
+                    "keywords": {
+                        " STOp\n": {"downstreams": ["http://c.com"], "responder": 0,},
+                        "start": {"downstreams": ["http://c.com"], "responder": None},
+                    },
+                }
+            ).encode()
+        )
+    ) == Config(
+        default=KeywordConfig(
+            downstreams=["http://a.com", "https://b.example.com:123/a/b?c#d"],
+            responder=1,
+        ),
+        keywords={
+            "stop": KeywordConfig(downstreams=["http://c.com"], responder=0),
+            "start": KeywordConfig(downstreams=["http://c.com"], responder=None),
+        },
+    )
+
+
+def test_missing_field():
+    with pytest.raises(ValidationError):
+        parse_config(
+            base64.b64encode(
+                json.dumps(
+                    {
+                        "keywords": {
+                            "STOP": {"downstreams": ["http://c.com"], "responder": 0,}
+                        },
+                    }
+                ).encode()
+            )
+        )
+
+
+def test_nested_error():
+    # default.downstreams is str, not list
+    with pytest.raises(ValidationError):
+        parse_config(
+            base64.b64encode(
+                json.dumps(
+                    {
+                        "default": {"downstreams": "http://a.com", "responder": 0,},
+                        "keywords": {
+                            "STOP": {"downstreams": ["http://c.com"], "responder": 0,}
+                        },
+                    }
+                ).encode()
+            )
+        )
+
+    # keywords.STOP is missing downstreams
+    with pytest.raises(ValidationError):
+        parse_config(
+            base64.b64encode(
+                json.dumps(
+                    {
+                        "default": {
+                            "downstreams": [
+                                "http://a.com",
+                                "https://b.example.com:123/a/b?c#d",
+                            ],
+                            "responder": 0,
+                        },
+                        "keywords": {"STOP": {"responder": 0}},
+                    }
+                ).encode()
+            )
+        )
+
+
+def test_negative_responder():
+    with pytest.raises(ValidationError):
+        parse_config(
+            base64.b64encode(
+                json.dumps(
+                    {
+                        "default": {
+                            "downstreams": [
+                                "http://a.com",
+                                "https://b.example.com:123/a/b?c#d",
+                            ],
+                            "responder": -1,
+                        },
+                        "keywords": {
+                            "STOP": {"downstreams": ["http://c.com"], "responder": 0,}
+                        },
+                    }
+                ).encode()
+            )
+        )
+
+
+def test_responder_oob():
+    with pytest.raises(ValidationError):
+        parse_config(
+            base64.b64encode(
+                json.dumps(
+                    {
+                        "default": {
+                            "downstreams": [
+                                "http://a.com",
+                                "https://b.example.com:123/a/b?c#d",
+                            ],
+                            "responder": 2,
+                        },
+                        "keywords": {
+                            "STOP": {"downstreams": ["http://c.com"], "responder": 0,}
+                        },
+                    }
+                ).encode()
+            )
+        )
+
+
+def test_invalid_url():
+    with pytest.raises(ValidationError):
+        parse_config(
+            base64.b64encode(
+                json.dumps(
+                    {
+                        "default": {
+                            "downstreams": [
+                                "xxx",
+                                "https://b.example.com:123/a/b?c#d",
+                            ],
+                            "responder": 1,
+                        },
+                        "keywords": {
+                            "STOP": {"downstreams": ["http://c.com"], "responder": 0,}
+                        },
+                    }
+                ).encode()
+            )
+        )

--- a/app/muxer.py
+++ b/app/muxer.py
@@ -1,8 +1,9 @@
 import os
 import concurrent.futures
-from typing import Any, Dict, List
+from typing import Any, Dict, List, Optional, Tuple
 from urllib.parse import parse_qsl
 import logging
+import sys
 
 import requests
 import sentry_sdk
@@ -10,13 +11,14 @@ import re
 from sentry_sdk.integrations.aws_lambda import AwsLambdaIntegration
 from twilio.request_validator import RequestValidator
 
-sentry_sdk.init(
-    dsn=os.environ["SENTRY_DSN"],
-    environment=os.environ["SENTRY_ENVIRONMENT"],
-    integrations=[AwsLambdaIntegration()],
-)
+from .config import Config, parse_config
+
 # Which request headers should be passed downstream
 PRESERVE_HEADERS = {"content-type", "i-twilio-idempotency-token", "user-agent"}
+
+# How long to wait for responses from downstreams (in seconds)
+# Twilio has a default timeout of 15 seconds we we will wait up to 10
+DOWNSTREAM_TIMEOUT = 10
 
 
 def is_nonempty_twiml_response(response: Any) -> bool:
@@ -37,27 +39,14 @@ def is_nonempty_twiml_response(response: Any) -> bool:
 
 
 class TwilioMuxer:
-    def __init__(
-        self, twilio_auth_token: str, muxer_url: str, downstream_urls: List[str]
-    ):
+    def __init__(self, twilio_auth_token: str, muxer_url: str, config: Config):
         self.validator = RequestValidator(twilio_auth_token)
         self.muxer_url = muxer_url
-        self.downstream_urls = downstream_urls
+        self.config = config
 
-    def make_downstream_request(
-        self, url: str, parsed_body: Dict[str, str], request_headers: Dict[str, str]
-    ):
-        downstream_headers = {
-            k: v for k, v in request_headers.items() if k.lower() in PRESERVE_HEADERS
-        }
-
-        downstream_headers["X-Twilio-Signature"] = self.validator.compute_signature(
-            url, parsed_body
-        )
-
-        return requests.post(url, data=parsed_body, headers=downstream_headers)
-
-    def mux_request(self, request_body: str, request_headers: Dict[str, str]):
+    def mux_request(
+        self, request_body: str, request_headers: Dict[str, str]
+    ) -> Tuple[int, str, Dict[str, str]]:
         parsed_body = dict(parse_qsl(request_body, keep_blank_values=True))
 
         request_valid = self.validator.validate(
@@ -71,53 +60,81 @@ class TwilioMuxer:
         if not request_valid:
             raise RuntimeError(f"Invalid Twilio signature")
 
-        with concurrent.futures.ThreadPoolExecutor() as executor:
-            futures = [
-                executor.submit(
-                    self.make_downstream_request, url, parsed_body, request_headers
+        request_body_normalized = parsed_body.get("Body", "").strip().lower()
+        request_config = self.config.keywords.get(
+            request_body_normalized, self.config.default
+        )
+
+        def make_downstream_request(url: str) -> Optional[requests.Response]:
+            downstream_headers = {
+                k: v
+                for k, v in request_headers.items()
+                if k.lower() in PRESERVE_HEADERS
+            }
+
+            downstream_headers["X-Twilio-Signature"] = self.validator.compute_signature(
+                url, parsed_body
+            )
+
+            try:
+                result = requests.post(
+                    url, data=parsed_body, headers=downstream_headers
                 )
-                for url in self.downstream_urls
-            ]
+            except Exception as e:
+                logging.exception(f"Request failed to downstream {url}")
+                sentry_sdk.capture_exception(e)
+                return None
 
-            response = None
-            for url, future in zip(self.downstream_urls, futures):
-                try:
-                    result = future.result()
-                except Exception as e:
-                    logging.exception(f"Request failed to downstream {url}")
-                    sentry_sdk.capture_exception(e)
-                    continue
+            try:
+                result.raise_for_status()
+            except Exception as e:
+                logging.exception(
+                    f"Request to downstream {url} return status code {result.status_code}"
+                )
+                sentry_sdk.capture_exception(e)
 
-                try:
-                    result.raise_for_status()
-                except Exception as e:
-                    logging.exception(
-                        f"Request to downstream {url} return status code {result.status_code}"
-                    )
-                    sentry_sdk.capture_exception(e)
-                    continue
+            # We return result whether or not raise_for_status() errored -- we're
+            # just doing raise_for_status so we can capture errors; we always want
+            # to return the result
+            return result
 
-                if (not response) and is_nonempty_twiml_response(result):
-                    response = result.text
+        with concurrent.futures.ThreadPoolExecutor() as executor:
+            results = list(
+                executor.map(make_downstream_request, request_config.downstreams)
+            )
 
-        return response or "<Response></Response>"
+        if request_config.responder is None:
+            return 200, "<Response></Response>", {"Content-Type": "application/xml"}
+
+        result = results[request_config.responder]
+        if result is None:
+            return 500, "<Response></Response>", {"Content-Type": "application/xml"}
+
+        return result.status_code, result.text, dict(result.headers)
 
 
-muxer = TwilioMuxer(
-    twilio_auth_token=os.environ["TWILIO_AUTH_TOKEN"],
-    muxer_url=os.environ["TWILIO_CALLBACK_URL"],
-    downstream_urls=[u.strip() for u in os.environ["DOWNSTREAM_URLS"].split(",")],
-)
+if "pytest" not in sys.modules:
+    sentry_sdk.init(
+        dsn=os.environ["SENTRY_DSN"],
+        environment=os.environ["SENTRY_ENVIRONMENT"],
+        integrations=[AwsLambdaIntegration()],
+    )
+
+    muxer = TwilioMuxer(
+        twilio_auth_token=os.environ["TWILIO_AUTH_TOKEN"],
+        muxer_url=os.environ["TWILIO_CALLBACK_URL"],
+        config=parse_config(os.environ["DOWNSTREAM_CONFIG"]),
+    )
 
 
 def handler(event: Any, context: Any):
     request_body = event["body"]
     request_headers = event["headers"]
 
-    twiml_response = muxer.mux_request(request_body, request_headers)
+    status_code, body, headers = muxer.mux_request(request_body, request_headers)
 
     return {
-        "statusCode": 200,
-        "headers": {"Content-Type": "application/xml"},
-        "body": twiml_response,
+        "statusCode": status_code,
+        "headers": headers,
+        "body": body,
     }

--- a/app/muxer.py
+++ b/app/muxer.py
@@ -98,10 +98,14 @@ class TwilioMuxer:
             # to return the result
             return result
 
+        print(f"Making requests to downstreams: {request_config.downstreams}")
         with concurrent.futures.ThreadPoolExecutor() as executor:
             results = list(
                 executor.map(make_downstream_request, request_config.downstreams)
             )
+
+        print(f"Downstream responses: {results}")
+        print(f"Taking result from responder: {request_config.responder}")
 
         if request_config.responder is None:
             return 200, "<Response></Response>", {"Content-Type": "application/xml"}
@@ -110,7 +114,11 @@ class TwilioMuxer:
         if result is None:
             return 500, "<Response></Response>", {"Content-Type": "application/xml"}
 
-        return result.status_code, result.text, dict(result.headers)
+        return (
+            result.status_code,
+            result.text,
+            {"Content-Type": result.headers.get("Content-Type", "application/xml")},
+        )
 
 
 if "pytest" not in sys.modules:

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
   "devDependencies": {
     "husky": "^4.2.5",
     "serverless-plugin-datadog": "^0.24.0",
+    "serverless-plugin-encode-env-var-objects": "^1.1.0",
     "serverless-prune-plugin": "^1.4.2"
   },
   "scripts": {

--- a/serverless.yml
+++ b/serverless.yml
@@ -38,7 +38,11 @@ provider:
 
     # The list of downstream targets to forward the webhooks to. Configure this
     # in the `custom` section below.
-    DOWNSTREAM_URLS: ${self:custom.downstreamURLs.${self:custom.stage}}
+    #
+    # If you are deploying without Serverless and setting this env var manually,
+    # this must be a base64-encoded JSON blob (we base64-encode because on
+    # Lambda, env vars can't contain commas)
+    DOWNSTREAM_CONFIG: ${self:custom.downstreamConfig.${self:custom.stage}}
 
   # Memory allocated to each lambda function
   memorySize: 256
@@ -67,12 +71,68 @@ plugins:
   # Custom domains: remove this to use an API Gateway-provided domain instead
   - serverless-domain-manager
 
+  # This takes the DOWNSTREAM_CONFIG env var above, serializes it as JSON,
+  # and then base64-encodes it. This is required because Lambda environment
+  # variables must be strings and cannot contain ",".
+  - serverless-plugin-encode-env-var-objects
+
 custom:
-  # The downstream URLs to sent to. Different per-environment. Comma-separated.
-  downstreamURLs:
-    local: https://example.com/foo,https://example.com/bar
-    staging: https://api-staging.voteamerica.com/v1/smsbot/twilio/,https://actionnetwork.org/groups/inbound_messages?group_id=160798
-    prod: https://api.voteamerica.com/v1/smsbot/twilio/,https://actionnetwork.org/groups/inbound_messages?group_id=158487
+  # The downstream URLs to sent to. Different per-environment. See the README
+  # for the schema.
+  downstreamConfig:
+    local:
+      default:
+        downstreams: ["https://fuzzy-va.ngrok.io/other", "https://fuzzy-va.ngrok.io/post"]
+        responder: 1
+      keywords:
+        STOP:
+          downstreams: ["https://fuzzy-va.ngrok.io/stop"]
+          responder: null
+        HELP:
+          downstreams: ["https://fuzzy-va.ngrok.io/help"]
+          responder: 0
+    staging:
+      default:
+        downstreams:
+          - https://helpline-staging.voteamerica.io/twilio-pull
+          - https://api-staging.voteamerica.com/v1/smsbot/twilio/
+          - https://actionnetwork.org/groups/inbound_messages?group_id=160798
+        responder: 0
+      keywords:
+        STOP:
+          downstreams:
+            - https://helpline-staging.voteamerica.io/twilio-pull
+            - https://api-staging.voteamerica.com/v1/smsbot/twilio/
+            - https://actionnetwork.org/groups/inbound_messages?group_id=160798
+          responder: null
+        HELP:
+          downstreams:
+            - https://api-staging.voteamerica.com/v1/smsbot/twilio/
+          responder: 0
+        JOIN:
+          downstreams:
+            - https://api-staging.voteamerica.com/v1/smsbot/twilio/
+          responder: 0
+    prod:
+      default:
+        downstreams:
+          - https://api.voteamerica.com/v1/smsbot/twilio/
+          - https://actionnetwork.org/groups/inbound_messages?group_id=158487
+        responder: 0
+      keywords:
+        STOP:
+          downstreams:
+            - https://api.voteamerica.com/v1/smsbot/twilio/
+            - https://actionnetwork.org/groups/inbound_messages?group_id=158487
+          responder: null
+        HELP:
+          downstreams:
+            - https://api.voteamerica.com/v1/smsbot/twilio/
+          responder: 0
+        JOIN:
+          downstreams:
+            - https://api.voteamerica.com/v1/smsbot/twilio/
+          responder: 0
 
   # The custom domain name to use for the muxer. You can remove this and
   # the serverless-domain-manager plugin to use an API Gateway-provided domain

--- a/serverless.yml
+++ b/serverless.yml
@@ -182,6 +182,7 @@ functions:
     events:
     - http:
         method: POST
+        integration: lambda-proxy
         path: /muxer
 
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2986,6 +2986,11 @@ lodash.values@^4.3.0:
   resolved "https://registry.yarnpkg.com/lodash.values/-/lodash.values-4.3.0.tgz#a3a6c2b0ebecc5c2cba1c17e6e620fe81b53d347"
   integrity sha1-o6bCsOvsxcLLocF+bmIP6BtT00c=
 
+lodash@4.17.4:
+  version "4.17.4"
+  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.4.tgz#78203a4d1c328ae1d86dca6460e369b57f4055ae"
+  integrity sha1-eCA6TRwyiuHYbcpkYONptX9AVa4=
+
 lodash@4.17.x, lodash@^4.17.11, lodash@^4.17.12, lodash@^4.17.14, lodash@^4.17.15, lodash@^4.17.19, lodash@^4.17.20:
   version "4.17.20"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.20.tgz#b44a9b6297bcb698f1c51a3545a2b3b368d59c52"
@@ -3974,6 +3979,13 @@ serverless-plugin-datadog@^0.24.0:
   version "0.24.0"
   resolved "https://registry.yarnpkg.com/serverless-plugin-datadog/-/serverless-plugin-datadog-0.24.0.tgz#80fe54582f788cacbba7b369ac9fd4eed5c87c81"
   integrity sha512-Sq3rfFmxgCAfVGQnGpLzvPSmG6yHG6wA1h6POzS7J0dcJaZBbpqwFBkZs+DwOaBcWht4FErYxaKbM3Mi66/0gg==
+
+serverless-plugin-encode-env-var-objects@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/serverless-plugin-encode-env-var-objects/-/serverless-plugin-encode-env-var-objects-1.1.0.tgz#173210d1544cc8ad2fdf9e0bd76dae2635c230af"
+  integrity sha1-FzIQ0VRMyK0v354L122uJjXCMK8=
+  dependencies:
+    lodash "4.17.4"
 
 serverless-prune-plugin@^1.4.2:
   version "1.4.3"


### PR DESCRIPTION
- Add a config blob to configure default vs. keyword downstreams
- Use a specific downstream for the response rather than the first non-empty response